### PR TITLE
Fix type-safe error handling to satisfy lint

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -27,10 +27,11 @@ export default function DashboardPage() {
 
         const data = await getEntries()
         setEntries(data)
-      } catch (err: any) {
-        setError(err.message || 'Failed to load entries')
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : 'Failed to load entries';
+        setError(message);
       } finally {
-        setLoading(false)
+        setLoading(false);
       }
     }
 
@@ -80,7 +81,7 @@ export default function DashboardPage() {
 
         {entries.length === 0 ? (
           <div className="text-center py-16">
-            <p className="text-warm-gray mb-6">You haven't written any entries yet.</p>
+            <p className="text-warm-gray mb-6">{"You haven't written any entries yet."}</p>
             <Link href="/new-entry">
               <button className="btn-secondary">Write your first entry</button>
             </Link>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -20,10 +20,11 @@ export default function LoginPage() {
     try {
       await signIn({ email, password })
       router.push('/dashboard')
-    } catch (err: any) {
-      setError(err.message || 'An error occurred during login')
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'An error occurred during login';
+      setError(message);
     } finally {
-      setLoading(false)
+      setLoading(false);
     }
   }
 
@@ -84,7 +85,7 @@ export default function LoginPage() {
 
           <div className="mt-6 text-center">
             <p className="text-sm text-warm-gray">
-              Don't have an account?{' '}
+              {"Don't have an account? "}
               <Link href="/signup" className="text-dark-brown hover:underline">
                 Sign up
               </Link>

--- a/src/app/new-entry/page.tsx
+++ b/src/app/new-entry/page.tsx
@@ -38,8 +38,10 @@ export default function NewEntryPage() {
 		try {
 			await createEntry({ title, content });
 			router.push("/dashboard");
-		} catch (err: any) {
-			setError(err.message || "Failed to create entry");
+		} catch (err: unknown) {
+			const message = err instanceof Error ? err.message : "Failed to create entry";
+			setError(message);
+		} finally {
 			setLoading(false);
 		}
 	};

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -32,10 +32,11 @@ export default function SignupPage() {
     try {
       await signUp({ email, password })
       router.push('/dashboard')
-    } catch (err: any) {
-      setError(err.message || 'An error occurred during signup')
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'An error occurred during signup';
+      setError(message);
     } finally {
-      setLoading(false)
+      setLoading(false);
     }
   }
 


### PR DESCRIPTION
Changed all catch blocks to use unknown instead of any and check errors with instanceof Error. 
This cleans up lint errors and makes error handling safer and consistent.