### PR TITLE
Fix incorrect title prefix 'Title är: '  added when creating or loading entries

### DIFF
--- a/src/app/entries/[id]/page.tsx
+++ b/src/app/entries/[id]/page.tsx
@@ -27,11 +27,7 @@ export default function EditEntryPage() {
 				}
 
 				const entry = await apiGetEntry(entryId);
-				// Remove "Title är: " prefix if it exists for editing
-				const cleanTitle = entry.title.startsWith("Title är: ")
-					? entry.title.substring(10)
-					: entry.title;
-				setTitle(cleanTitle);
+				setTitle(entry.title);
 				setContent(entry.content);
 				setCreatedAt(entry.created_at);
 			} catch (err: unknown) {

--- a/src/lib/supabase/queries.ts
+++ b/src/lib/supabase/queries.ts
@@ -58,7 +58,7 @@ export async function createEntry(entry: NewEntry): Promise<Entry> {
     .insert([
       {
         user_id: user.id,
-        title: `Title är: ${entry.title}`,
+        title: entry.title,
         content: entry.content,
         created_at: new Date().toISOString()
       }
@@ -83,7 +83,7 @@ export async function updateEntry(id: string, entry: NewEntry): Promise<Entry> {
   const { data, error } = await supabase
     .from('entries')
     .update({
-      title: `Title är: ${entry.title}`,
+      title: entry.title,
       content: entry.content
     })
     .eq('id', id)


### PR DESCRIPTION
+ Also cleaned up in Supabase DB, removed all "Title är: " in all titles.