### PR TITLE
Ci/render deploy hook

### DIFF
--- a/.github/workflows/docker-publish-render.yml
+++ b/.github/workflows/docker-publish-render.yml
@@ -38,3 +38,4 @@ jobs:
       - name: Trigger Render deploy
         run: |
           curl -sS -f -X POST ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
+


### PR DESCRIPTION
Setup automatic Render deploy from main

This PR sets up the infrastructure to automatically deploy the app to Render whenever the main branch is updated.

- Adds a GitHub Actions workflow (docker-publish-render.yml) to build and push the Docker image to Docker Hub.
- Introduces a secret (RENDER_DEPLOY_HOOK_URL) to trigger Render deploy via webhook.
- No changes to application code; this is purely a CI/CD setup.

This ensures that future merges to main will automatically deploy the latest Docker image to Render.