### PR TITLE
ci: setup automatic Render deploy from main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,14 @@ on:
 
 jobs:
   lint-and-tests:
+    name: Lint and Run Tests
     runs-on: ubuntu-latest
 
     steps:
-      # Clone the repo to provide to Github actions runner
+      # Clone the repo to provide to GitHub Actions runner
       - uses: actions/checkout@v4
 
-      # Setup node
+      # Setup Node.js
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,27 +1,27 @@
-# .github/workflows/docker-publish-render.yml
-name: Build & Push Docker Image for Render
+# .github/workflows/docker-publish.yml
+name: Docker Publish
 
 on:
   push:
     branches:
-      - main  # Trigger only on merges to main
+      - main  # Trigger only when main branch is updated
 
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
 
     steps:
-      # 1. Checkout repo
+      # Checkout the repository
       - uses: actions/checkout@v4
 
-      # 2. Log in to Docker Hub
+      # Log in to Docker Hub
       - name: Log in to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      # 3. Build Docker image with NEXT_PUBLIC_* build-args
+      # Build the Docker image with Supabase build-args
       - name: Build Docker image
         run: |
           docker build \
@@ -29,7 +29,7 @@ jobs:
             --build-arg NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }} \
             -t chasteam2/journal-app:latest .
 
-      # 4. Push Docker image to Docker Hub
+      # Push the image to Docker Hub
       - name: Push Docker image
         run: |
           docker push chasteam2/journal-app:latest

--- a/.github/workflows/render-deploy.yml
+++ b/.github/workflows/render-deploy.yml
@@ -1,0 +1,23 @@
+# .github/workflows/render-deploy.yml
+name: Render Deploy
+
+on:
+  push:
+    branches:
+      - main  # Trigger only when main branch is updated
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the repository (optional)
+      - uses: actions/checkout@v4
+
+      # Trigger the Render deploy webhook
+      - name: Trigger Render deploy
+        env:
+          DEPLOY_HOOK_URL: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
+        run: |
+          curl -sS -f -X POST $DEPLOY_HOOK_URL
+          echo "Triggered Render deploy webhook"


### PR DESCRIPTION
### Setup automatic Render deploy from main
This PR sets up the infrastructure to automatically deploy the app to Render whenever the main branch is updated.

- Adds GitHub Actions workflows (docker-publish.yml & render-deploy.yml) to build and push the Docker image to Docker Hub, and trigger the Render deploy via webhook.
- Introduces a secret (RENDER_DEPLOY_HOOK_URL) to trigger Render deploy.
- No changes to application code; this is purely a CI/CD setup.

This ensures that future merges to main will automatically deploy the latest Docker image to Render.